### PR TITLE
fix: Fix that onOpen and onClose is not dispatched.

### DIFF
--- a/src/asModal/index.tsx
+++ b/src/asModal/index.tsx
@@ -43,6 +43,8 @@ const asModal = <P extends ModalProps>(
       // trapFocus: true,
       // returnFocus: true,
       classPrefix: classPrefixFromProps,
+      onOpen,
+      onClose,
       onEnter,
       onEntering,
       onEntered,
@@ -58,6 +60,7 @@ const asModal = <P extends ModalProps>(
     const classPrefixToUse = classPrefixFromProps || classPrefixFromContext;
     const slug = slugFromArg || slugFromProp;
 
+    const isInitialized = useRef(openOnInit);
     const isOpen = modalState[slug] && modalState[slug].isOpen;
 
     useEffect(() => {
@@ -135,6 +138,22 @@ const asModal = <P extends ModalProps>(
     }, [
       isOpen,
       transTime,
+    ]);
+
+    useEffect(() => {
+      if (isOpen) {
+        onOpen?.();
+      } else if (isInitialized.current) {
+        onClose?.();
+      }
+
+      if (!isInitialized.current) {
+        isInitialized.current = true;
+      }
+    }, [
+      isOpen,
+      onOpen,
+      onClose
     ]);
 
     useEffect(() => {


### PR DESCRIPTION
## Related To: payloadcms/payload#4116

There are issues in payload becuase onClose is not dispatched. So I Added side effects for onOpen and onClose.

I added `isInitialized` because I think onClose must be not dispatched when modal is initalized and closed.