### PR TITLE
chore: adds use client directive

### DIFF
--- a/src/Modal/index.tsx
+++ b/src/Modal/index.tsx
@@ -1,3 +1,4 @@
+'use client'
 import * as focusTrap from 'focus-trap';
 import React, { Fragment, ElementType, HTMLProps } from 'react';
 import asModal from '../asModal';

--- a/src/ModalContainer/index.tsx
+++ b/src/ModalContainer/index.tsx
@@ -1,3 +1,4 @@
+'use client'
 import React, { MouseEvent, ElementType, HTMLProps } from 'react';
 import { CSSTransition } from 'react-transition-group';
 import useModal from '../useModal';

--- a/src/ModalProvider/context.tsx
+++ b/src/ModalProvider/context.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { createContext } from 'react';
 import { ModalProviderProps } from '../ModalProvider';
 

--- a/src/ModalProvider/index.tsx
+++ b/src/ModalProvider/index.tsx
@@ -1,3 +1,4 @@
+'use client'
 import React, {
   Fragment,
   useState,

--- a/src/ModalToggler/index.tsx
+++ b/src/ModalToggler/index.tsx
@@ -1,3 +1,4 @@
+'use client'
 import React, { ElementType, HTMLProps, MouseEvent } from 'react';
 import { IModalContext } from '../ModalProvider/context';
 import useModal from '../useModal';

--- a/src/asModal/index.tsx
+++ b/src/asModal/index.tsx
@@ -1,3 +1,4 @@
+'use client'
 import React, {
   useRef,
   useEffect,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+'use client'
 export { default as asModal } from './asModal';
 export { default as Modal } from './Modal';
 export { default as ModalContainer } from './ModalContainer';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-'use client'
 export { default as asModal } from './asModal';
 export { default as Modal } from './Modal';
 export { default as ModalContainer } from './ModalContainer';

--- a/src/useModal/index.tsx
+++ b/src/useModal/index.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { useContext } from 'react';
 import ModalContext, { IModalContext } from '../ModalProvider/context';
 


### PR DESCRIPTION
Adds the `use client` directive to every client-side component so that they can be directly imported into React Server Components.