### PR TITLE
chore: properly sets webpack dev compiler options

### DIFF
--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -23,8 +23,7 @@ const config = {
         options: {
           transpileOnly: true,
           compilerOptions: {
-            module: "commonjs",
-            target: "es5",
+            module: "ESNext",
             moduleResolution: "node",
           }
         },


### PR DESCRIPTION
The Webpack compiler options were improperly resolving modules to `commonjs` instead of `NodeNext`. This led to the demo not being able to be booted.