### PR TITLE
chore: removes publishConfig from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,24 +2,13 @@
   "name": "@faceless-ui/modal",
   "version": "3.0.0-beta.1",
   "type": "module",
-  "main": "src/index.ts",
-  "types": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./src/index.ts",
-      "types": "./src/index.ts",
-      "default": "./src/index.ts"
-    }
-  },
-  "publishConfig": {
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "exports": {
-      ".": {
-        "import": "./dist/index.js",
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
   "sideEffects": false,


### PR DESCRIPTION
The `publishConfig` property in `package.json` only seems to be supported by `pnpm publish`.

There's an [issue for yarn not respecting it](https://github.com/yarnpkg/yarn/issues/5310), couldn't find one for `npm` though.