### PR TITLE
chore(deps): bump react to v19 stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "dependencies": {
     "body-scroll-lock": "4.0.0-beta.0",
@@ -90,8 +90,8 @@
     "eslint-webpack-plugin": "^3.1.1",
     "html-webpack-plugin": "^5.5.0",
     "jest": "^28.0.2",
-    "react": "^19.0.0-rc.0",
-    "react-dom": "^19.0.0-rc.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "react-refresh": "^0.13.0",
     "react-refresh-typescript": "^2.0.4",
     "ts-loader": "^9.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,10 +82,10 @@ importers:
         specifier: ^28.0.2
         version: 28.1.3(@types/node@14.18.63)
       react:
-        specifier: ^19.0.0-rc.0
+        specifier: ^19.0.0
         version: 19.1.1
       react-dom:
-        specifier: ^19.0.0-rc.0
+        specifier: ^19.0.0
         version: 19.1.1(react@19.1.1)
       react-refresh:
         specifier: ^0.13.0


### PR DESCRIPTION
Bumps React peer and dev deps from `19.0.0-rc.0` to `19.0.0` stable.