### PR TITLE
chore: use https url for repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "sideEffects": false,
   "homepage:": "https://facelessui.com/docs/modal",
-  "repository": "git@github.com:faceless-ui/modal.git",
+  "repository": "git+https://github.com/faceless-ui/modal.git",
   "description": "America's next top modal",
   "author": {
     "email": "dev@facelessui.com",


### PR DESCRIPTION
## Summary
- update the package repository metadata from the SSH shorthand to a public `git+https` URL [[Spec]](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#repository)

## Validation
- `node -e 'const p=require("./package.json"); if (p.repository !== "git+https://github.com/faceless-ui/modal.git") throw new Error(p.repository); console.log(p.name, p.version, p.repository)'`\n- `npm pack --dry-run --json`