### PR TITLE
fix: generate modal CSS during render so it is present in SSR output

### DIFF
--- a/src/ModalProvider/index.tsx
+++ b/src/ModalProvider/index.tsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   useEffect,
   useCallback,
+  useMemo,
   useReducer,
 } from 'react';
 import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock';
@@ -73,8 +74,20 @@ export const ModalProvider: React.FC<ModalProviderProps> = (props) => {
   const [oneIsOpen, setOneIsOpen] = useState(false);
   const [closeOnBlur, setCloseOnBlur] = useState(false);
   const [bodyScrollIsLocked, setBodyScrollIsLocked] = useState(false);
-  const [cssString, setCSSString] = useState('');
   const escIsBound = useRef(false);
+
+  // Generate CSS synchronously during render so the <style> tag is present in
+  // the server-rendered HTML and the first hydration frame. Computing it in an
+  // effect (client-only) left closed modals unstyled until after hydration,
+  // causing them to flash into view under SSR frameworks like TanStack Start.
+  const cssString = useMemo(() => {
+    if (!shouldGenerateCSS) return '';
+    const newString = generateCSS({
+      classPrefix,
+      zIndex,
+    });
+    return minifyCSS ? newString.replace(/\n/g, '').replace(/\s\s+/g, ' ') : newString;
+  }, [shouldGenerateCSS, minifyCSS, zIndex, classPrefix]);
 
   const bindEsc = useCallback((e: KeyboardEvent) => {
     if (e.keyCode === 27) {
@@ -96,25 +109,6 @@ export const ModalProvider: React.FC<ModalProviderProps> = (props) => {
       }
     }
   }, [bindEsc]);
-
-  // Generate CSS to inject into stylesheet
-  useEffect(() => {
-    if (shouldGenerateCSS) {
-      let newString = '';
-      newString = generateCSS({
-        classPrefix,
-        zIndex
-      });
-
-      if (minifyCSS) newString = newString.replace(/\n/g, '').replace(/\s\s+/g, ' ');
-      setCSSString(newString);
-    }
-  }, [
-    shouldGenerateCSS,
-    minifyCSS,
-    zIndex,
-    classPrefix
-  ]);
 
   // Handle param changes
   useEffect(() => {


### PR DESCRIPTION
The ModalProvider generated its visibility CSS inside a useEffect and stored it in state initialized to an empty string. Effects only run on the client after hydration, so the injected <style> was empty during server rendering and the first hydration frames.

Because consumers style modals regardless of their open state, any registered-but-closed modal (e.g. a confirmation dialog) rendered visible until the effect filled the <style>, flashing on screen after a refresh under SSR frameworks such as TanStack Start.

generateCSS is a pure function of classPrefix/zIndex/minifyCSS with no browser APIs, so compute it synchronously with useMemo during render instead. The <style> is now part of the server-rendered HTML, and because server and client produce a byte-identical string there is no hydration mismatch.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216204011123959